### PR TITLE
feat(frontend): integrate react router

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^7.8.0",
         "recharts": "^3.1.0"
       },
       "devDependencies": {
@@ -2238,6 +2239,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3870,6 +3880,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.0.tgz",
+      "integrity": "sha512-r15M3+LHKgM4SOapNmsH3smAizWds1vJ0Z9C4mWaKnT9/wD7+d/0jYcj6LmOvonkrO4Rgdyp4KQ/29gWN2i1eg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.0.tgz",
+      "integrity": "sha512-ntInsnDVnVRdtSu6ODmTQ41cbluak/ENeTif7GBce0L6eztFg6/e1hXAysFQI8X25C8ipKmT9cClbJwxx3Kaqw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -4062,6 +4110,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^7.8.0",
     "recharts": "^3.1.0"
   },
   "devDependencies": {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,18 +1,14 @@
 import favicon from "../assets/favicon.png";
 
+import { useNavigate } from "react-router-dom";
+
 interface HeaderProps {
   nome?: string;
-  onLogin?: () => void;
   onLogout?: () => void;
-  onProfile?: () => void;
 }
 
-export default function Header({
-  nome,
-  onLogin,
-  onLogout,
-  onProfile,
-}: HeaderProps) {
+export default function Header({ nome, onLogout }: HeaderProps) {
+  const navigate = useNavigate();
   return (
     <header className="flex justify-between items-center bg-white/80 backdrop-blur-md p-4 shadow-md fixed top-0 left-0 right-0 w-full border-b border-gray-200 z-50">
       <div className="flex items-center space-x-3">
@@ -32,7 +28,7 @@ export default function Header({
               Benvenuto, <strong>{nome}</strong>
             </span>
             <button
-              onClick={onProfile}
+              onClick={() => navigate("/profile")}
               className="px-4 py-2 rounded-xl bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium transition-colors duration-200 shadow-sm"
             >
               Profilo
@@ -46,7 +42,7 @@ export default function Header({
           </>
         ) : (
           <button
-            onClick={onLogin}
+            onClick={() => navigate("/login")}
             className="px-5 py-2 rounded-xl bg-blue-600 hover:bg-blue-700 text-white font-medium transition-colors duration-200 shadow-sm"
           >
             Login

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -2,6 +2,7 @@
 // LoginPage
 // =============================
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { login } from "../services/api";
 
 interface Props {
@@ -11,10 +12,10 @@ interface Props {
     email: string,
     nome: string
   ) => void;
-  onBackToHome: () => void;
 }
 
-export default function LoginPage({ onLogged, onBackToHome }: Props) {
+export default function LoginPage({ onLogged }: Props) {
+  const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
@@ -89,13 +90,22 @@ export default function LoginPage({ onLogged, onBackToHome }: Props) {
           Accedi
         </button>
 
-        <button
-          type="button"
-          onClick={onBackToHome}
-          className="w-full text-blue-700 hover:text-blue-800 hover:bg-blue-50 font-medium py-3 rounded-2xl transition-colors duration-200"
-        >
-          Torna alla home
-        </button>
+        <div className="flex flex-col space-y-3">
+          <button
+            type="button"
+            onClick={() => navigate("/")}
+            className="w-full text-blue-700 hover:text-blue-800 hover:bg-blue-50 font-medium py-3 rounded-2xl transition-colors duration-200"
+          >
+            Torna alla home
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate("/register")}
+            className="w-full text-white bg-green-600 hover:bg-green-700 font-medium py-3 rounded-2xl transition-colors duration-200"
+          >
+            Registrati
+          </button>
+        </div>
       </form>
 
       <p className="mt-6 text-center text-xs text-gray-500">

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { register } from "../services/api";
 
 interface Props {
@@ -6,6 +7,7 @@ interface Props {
 }
 
 export default function RegisterPage({ onRegistered }: Props) {
+  const navigate = useNavigate();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [nome, setNome] = useState("");
@@ -130,6 +132,13 @@ export default function RegisterPage({ onRegistered }: Props) {
             className="bg-blue-600 text-white py-2 rounded-md hover:bg-blue-700 transition duration-200"
           >
             Registrati
+          </button>
+          <button
+            type="button"
+            onClick={() => navigate("/login")}
+            className="bg-green-600 text-white py-2 rounded-md hover:bg-green-700 transition duration-200"
+          >
+            Accedi
           </button>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- install `react-router-dom`
- replace `mode` state with `BrowserRouter` routes for core pages
- navigate via `useNavigate` in header and auth pages

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689745de5c10832a9cfa7b5bac2dff83